### PR TITLE
feat: t11 implementation and some fixes

### DIFF
--- a/T11/main.ml
+++ b/T11/main.ml
@@ -1,0 +1,63 @@
+open Numerical
+
+let () =
+  print_endline "Primeiro problema:";
+  let a1_matrix = [| [| 5.; 2.; 1. |]; [| 2.; 3.; 1. |]; [| 1.; 1.; 2. |] |]
+  and init_vector = [| 1.; 0.; 0. |] in
+  let ((lambda_1, _) as p1) =
+    Linear.regular_power_iteration a1_matrix init_vector epsilon_float
+  in
+  let ((lambda_2, _) as p2) =
+    Linear.inverse_power_iteration a1_matrix init_vector epsilon_float
+  in
+  let p3 =
+    Linear.shifted_power_iteration a1_matrix init_vector epsilon_float
+      ((lambda_1 +. lambda_2) /. 2.)
+  in
+  Linear.print_eigen [ p1; p2; p3 ];
+
+  print_endline "Segundo problema:";
+  let a2_matrix =
+    [| [| -14.; 1.; -2. |]; [| 1.; -1.; 1. |]; [| -2.; 1.; -11. |] |]
+  and init_vector = [| 1.; 0.; 0. |] in
+  let ((lambda_1, _) as p1) =
+    Linear.regular_power_iteration a2_matrix init_vector epsilon_float
+  in
+  let ((lambda_2, _) as p2) =
+    Linear.inverse_power_iteration a2_matrix init_vector epsilon_float
+  in
+  let p3 =
+    Linear.shifted_power_iteration a2_matrix init_vector epsilon_float
+      ((lambda_1 +. lambda_2) /. 2.)
+  in
+  Linear.print_eigen [ p1; p2; p3 ];
+
+  print_endline "Terceiro problema:";
+  let a3_matrix =
+    [|
+      [| 40.; 8.; 4.; 2.; 1. |];
+      [| 8.; 30.; 12.; 6.; 2. |];
+      [| 4.; 12.; 20.; 1.; 2. |];
+      [| 2.; 6.; 1.; 25.; 4. |];
+      [| 1.; 2.; 2.; 4.; 5. |];
+    |]
+  and init_vector = [| 1.; 0.; 0.; 0.; 0. |] in
+  let ((lambda_1, _) as p1) =
+    Linear.regular_power_iteration a3_matrix init_vector epsilon_float
+  in
+  let ((lambda_2, _) as p2) =
+    Linear.inverse_power_iteration a3_matrix init_vector epsilon_float
+  in
+  let ((lambda_3, _) as p3) =
+    Linear.shifted_power_iteration a3_matrix init_vector epsilon_float
+      ((lambda_1 +. lambda_2) /. 2.)
+  in
+  let p4 =
+    Linear.shifted_power_iteration a3_matrix init_vector epsilon_float
+      ((lambda_3 +. lambda_2) /. 2.)
+  in
+  let p5 =
+    Linear.shifted_power_iteration a3_matrix init_vector epsilon_float
+      ((lambda_3 +. lambda_1) /. 2.)
+  in
+  Linear.print_eigen [ p1; p2; p3; p4; p5 ]

--- a/lib/linear.ml
+++ b/lib/linear.ml
@@ -32,6 +32,14 @@ let dot_product v1 v2 =
 
   dot_prod 0 0.
 
+let sub_matrix m1 m2 =
+  let n = Array.length m1 in
+  Array.init n (fun i -> Array.init n (fun j -> m1.(i).(j) -. m2.(i).(j)))
+
+let scale_matrix lambda mat =
+  let n = Array.length mat in
+  Array.init n (fun i -> Array.init n (fun j -> mat.(i).(j) *. lambda))
+
 let apply_matrix mat vec =
   let columns = Array.length mat and n = Array.length vec in
   assert (n = columns);
@@ -47,6 +55,21 @@ let print_vector arr =
   print_string "]";
   print_newline ()
 
+let print_eigen lambda_list =
+  let print_pair (lamb, vec) =
+    print_endline ("Autovalor: " ^ string_of_float lamb);
+    print_string "Autovetor: ";
+    print_vector vec
+  in
+  let rec print_lambdas lambda_l =
+    match lambda_l with
+    | [] -> ()
+    | h :: t ->
+        print_pair h;
+        print_lambdas t
+  in
+  print_lambdas lambda_list
+
 let regular_power_iteration mat vec epsilon =
   let rec power_iteration new_lambda new_vec_k =
     let old_lambda = new_lambda in
@@ -61,7 +84,8 @@ let regular_power_iteration mat vec epsilon =
   power_iteration 0. vec
 
 let lu_decomposition mat =
-  let n = Array.length mat and u = Array.copy mat in
+  let n = Array.length mat in
+  let u = Array.init n (fun i -> Array.copy mat.(i)) in
   let l = identity_matrix n in
 
   for i = 0 to n - 2 do
@@ -115,3 +139,9 @@ let inverse_power_iteration mat vec epsilon =
     else (1. /. new_lambda, old_x1)
   in
   inverse_iteration 0. vec
+
+let shifted_power_iteration mat vec epsilon mi =
+  let id_matrix = identity_matrix (Array.length mat) in
+  let shifted_mat = sub_matrix mat (scale_matrix mi id_matrix) in
+  let lambda, eigen_vec = inverse_power_iteration shifted_mat vec epsilon in
+  (lambda +. mi, eigen_vec)

--- a/lib/linear.mli
+++ b/lib/linear.mli
@@ -15,3 +15,7 @@ val solve_lu : matrix -> matrix -> vector -> vector
 val inverse_power_iteration : matrix -> vector -> float -> float * vector
 val solve_lower : matrix -> vector -> vector
 val solve_upper : matrix -> vector -> vector
+val print_eigen : (float * vector) list -> unit
+
+val shifted_power_iteration :
+  matrix -> vector -> float -> float -> float * vector


### PR DESCRIPTION
Não usar "Array.copy" para copiar matrizes. Os elementos internos (arrays) são mutáveis e não devem ser copiados. 